### PR TITLE
Publish artifacts to maven central

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -148,7 +148,7 @@ jobs:
       - restore_cache: { key: 'gradle-wrapper-v2-{{ checksum "gradle/wrapper/gradle-wrapper.properties" }}' }
       - restore_cache: { key: 'publish-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}' }
       - deploy:
-          command: ./gradlew --parallel --stacktrace --continue publish
+          command: ./gradlew --parallel --stacktrace --continue publish publishToSonatype closeAndReleaseSonatypeStagingRepository
       - save_cache:
           key: 'publish-gradle-cache-v2-{{ checksum "versions.props" }}-{{ checksum "build.gradle" }}'
           paths: [ ~/.gradle/caches ]

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,11 @@ buildscript {
     }
 }
 
+plugins {
+  id 'signing'
+  id 'io.github.gradle-nexus.publish-plugin' version '1.0.0'
+}
+
 apply plugin: 'com.palantir.baseline-config'
 apply plugin: 'com.palantir.baseline-idea'
 apply plugin: 'com.palantir.git-version'
@@ -42,6 +47,9 @@ apply plugin: 'com.palantir.baseline'
 allprojects {
     group 'com.palantir.human-readable-types'
     version gitVersion()
+
+    description = """This repository provides a collection of useful types that can be deserialized from human-readable strings.
+These types can be particularly useful for use in POJOs deserialized from configuration files where legibility is important."""
 
     repositories {
         mavenCentral()
@@ -88,4 +96,16 @@ subprojects {
     tasks.withType(Test) {
         systemProperty 'recreate', System.getProperty('recreate', 'false')
     }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            stagingProfileId = 'com.palantir'
+        }
+    }
+
+    // Be resilient against sonatype publishing issues
+    connectTimeout = Duration.ofMinutes(3)
+    clientTimeout = Duration.ofMinutes(3)
 }

--- a/build.gradle
+++ b/build.gradle
@@ -100,7 +100,10 @@ subprojects {
 
 nexusPublishing {
     repositories {
-        sonatype()
+        sonatype {
+            username = System.env.SONATYPE_USERNAME
+            password = System.env.SONATYPE_PASSWORD
+        }
     }
 
     // Be resilient against sonatype publishing issues

--- a/build.gradle
+++ b/build.gradle
@@ -100,9 +100,7 @@ subprojects {
 
 nexusPublishing {
     repositories {
-        sonatype {
-            stagingProfileId = 'com.palantir'
-        }
+        sonatype()
     }
 
     // Be resilient against sonatype publishing issues

--- a/gradle/publish-jar.gradle
+++ b/gradle/publish-jar.gradle
@@ -10,13 +10,15 @@ apply plugin: 'nebula.maven-manifest'
 apply plugin: 'nebula.info-scm'
 apply plugin: 'nebula.maven-scm'
 
-apply plugin: 'nebula.javadoc-jar'
-apply plugin: 'nebula.source-jar'
-
 jar {
     manifest {
         attributes("Implementation-Version" : project.version)
     }
+}
+
+java {
+  withJavadocJar()
+  withSourcesJar()
 }
 
 bintray {
@@ -37,13 +39,24 @@ bintrayUpload.onlyIf {
     versionDetails().isCleanTag
 }
 
-// See: https://docs.gradle.org/5.2/userguide/publishing_maven.html#publishing_maven:resolved_dependencies
-// This replaces nebula.maven-resolved-dependencies, which doesn't work with the 'com.gradle.plugin-publish' plugin
 publishing {
-    publications.withType(MavenPublication).configureEach {
-        versionMapping {
-            allVariants {
-                fromResolutionResult()
+    publications {
+        maven(MavenPublication) {
+            from(components.java)
+            pom {
+                licenses {
+                    license {
+                        name = "The Apache License, Version 2.0"
+                        url = "https://www.apache.org/licenses/LICENSE-2.0"
+                    }
+                }
+                developers {
+                    developer {
+                        id = "palantir"
+                        name = "palantir"
+                        organizationUrl = "https://www.palantir.com"
+                    }
+                }
             }
         }
     }
@@ -52,4 +65,10 @@ publishing {
 // Turning off module metadata so that all consumers just use regular POMs
 tasks.withType(GenerateModuleMetadata) {
     enabled = false
+}
+
+signing {
+  useInMemoryPgpKeys(findProperty("signingKey"), findProperty("signingPassword"))
+
+  sign publishing.publications.maven
 }

--- a/gradle/publish-jar.gradle
+++ b/gradle/publish-jar.gradle
@@ -70,7 +70,6 @@ tasks.withType(GenerateModuleMetadata) {
 def hasSigningKey = project.findProperty("signingKey") && project.findProperty("signingKeyId")
 if(hasSigningKey) {
     signing {
-        required { project.gradle.taskGraph.hasTask("publish") }
         // Expect that the gpg key is base64 decoded as a secret in CircleCI
         // to avoid problems with newlines in CircleCI env vars
         useInMemoryPgpKeys(findProperty("signingKeyId"), new String(findProperty("signingKey").decodeBase64()), findProperty("signingPassword"))

--- a/gradle/publish-jar.gradle
+++ b/gradle/publish-jar.gradle
@@ -67,8 +67,14 @@ tasks.withType(GenerateModuleMetadata) {
     enabled = false
 }
 
-signing {
-  useInMemoryPgpKeys(findProperty("signingKey"), findProperty("signingPassword"))
+def hasSigningKey = project.findProperty("signingKey")
+if(hasSigningKey) {
+    signing {
+        required { project.gradle.taskGraph.hasTask("publish") }
+        // Expect that the gpg key is base64 decoded as a secret in CircleCI
+        // to avoid problems with newlines in CircleCI env vars
+        useInMemoryPgpKeys(new String(findProperty("signingKey").decodeBase64()), findProperty("signingPassword"))
 
-  sign publishing.publications.maven
+        sign publishing.publications.maven
+    }
 }

--- a/gradle/publish-jar.gradle
+++ b/gradle/publish-jar.gradle
@@ -67,13 +67,13 @@ tasks.withType(GenerateModuleMetadata) {
     enabled = false
 }
 
-def hasSigningKey = project.findProperty("signingKey")
+def hasSigningKey = project.findProperty("signingKey") && project.findProperty("signingKeyId")
 if(hasSigningKey) {
     signing {
         required { project.gradle.taskGraph.hasTask("publish") }
         // Expect that the gpg key is base64 decoded as a secret in CircleCI
         // to avoid problems with newlines in CircleCI env vars
-        useInMemoryPgpKeys(new String(findProperty("signingKey").decodeBase64()), findProperty("signingPassword"))
+        useInMemoryPgpKeys(findProperty("signingKeyId"), new String(findProperty("signingKey").decodeBase64()), findProperty("signingPassword"))
 
         sign publishing.publications.maven
     }

--- a/gradle/publish-jar.gradle
+++ b/gradle/publish-jar.gradle
@@ -67,12 +67,12 @@ tasks.withType(GenerateModuleMetadata) {
     enabled = false
 }
 
-def hasSigningKey = project.findProperty("signingKey") && project.findProperty("signingKeyId")
+def hasSigningKey = System.env.GPG_SIGNING_KEY && System.env.GPG_SIGNING_KEY_ID
 if(hasSigningKey) {
     signing {
         // Expect that the gpg key is base64 decoded as a secret in CircleCI
         // to avoid problems with newlines in CircleCI env vars
-        useInMemoryPgpKeys(findProperty("signingKeyId"), new String(findProperty("signingKey").decodeBase64()), findProperty("signingPassword"))
+        useInMemoryPgpKeys(System.env.GPG_SIGNING_KEY_ID, new String(System.env.GPG_SIGNING_KEY.decodeBase64()), System.env.GPG_SIGNING_KEY_PASSWORD)
 
         sign publishing.publications.maven
     }


### PR DESCRIPTION
## Before this PR
<!-- What's wrong with the current state of the world and why change it now? -->
We only published to bintray, which is being [shut down](https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/). 

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Jars are published to maven central.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->
There is some additional complexity to set up publishing: a new gradle plugin, as well as new credentials and signing keys for CI.

