### PR TITLE
Replace HumanReadableByteCount `getSize`/`getUnit` with more obvious `map(func)`

### DIFF
--- a/changelog/@unreleased/pr-286.v2.yml
+++ b/changelog/@unreleased/pr-286.v2.yml
@@ -1,0 +1,6 @@
+type: improvement
+improvement:
+  description: Replace HumanReadableByteCount `getSize`/`getUnit` with more obvious
+    `map(func)`
+  links:
+  - https://github.com/palantir/human-readable-types/pull/286

--- a/human-readable-types/src/main/java/com/palantir/humanreadabletypes/HumanReadableByteCount.java
+++ b/human-readable-types/src/main/java/com/palantir/humanreadabletypes/HumanReadableByteCount.java
@@ -186,9 +186,9 @@ public final class HumanReadableByteCount implements Comparable<HumanReadableByt
         /**
          * A method allowing the raw quantity and unit values to be interpreted into a more specific type.
          *
-         * @param quantity Raw number of the given {@code unit}.
-         * @param unit Unit which the {@code quantity represents}.
-         * @return A representation of the byte-count value.
+         * @param quantity Raw number of the given {@code unit}
+         * @param unit Unit which the {@code quantity represents}
+         * @return A representation of the byte-count value
          */
         T apply(long quantity, ByteUnit unit);
     }

--- a/human-readable-types/src/test/java/com/palantir/humanreadabletypes/HumanReadableByteCountTests.java
+++ b/human-readable-types/src/test/java/com/palantir/humanreadabletypes/HumanReadableByteCountTests.java
@@ -22,6 +22,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.TextNode;
+import com.palantir.humanreadabletypes.HumanReadableByteCount.ByteUnit;
+import com.palantir.logsafe.exceptions.SafeNullPointerException;
 import java.util.Arrays;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -112,6 +114,20 @@ public final class HumanReadableByteCountTests {
         assertThat(toJsonString(HumanReadableByteCount.valueOf("1 bytes"))).isEqualTo("\"1 byte\"");
         assertThat(toJsonString(HumanReadableByteCount.valueOf("2 byte"))).isEqualTo("\"2 bytes\"");
         assertThat(toJsonString(HumanReadableByteCount.valueOf("2 bytes"))).isEqualTo("\"2 bytes\"");
+    }
+
+    @Test
+    public void testMapNulls() {
+        HumanReadableByteCount bytes = HumanReadableByteCount.valueOf("1 byte");
+        assertThatThrownBy(() -> bytes.map(null)).isInstanceOf(SafeNullPointerException.class);
+        assertThatThrownBy(() -> bytes.map((_val, _unit) -> null)).isInstanceOf(SafeNullPointerException.class);
+    }
+
+    @Test
+    public void testMap() {
+        HumanReadableByteCount bytes = HumanReadableByteCount.valueOf("5mb");
+        assertThat(bytes.<ByteUnit>map((_quantity, unit) -> unit)).isEqualTo(ByteUnit.MiB);
+        assertThat(bytes.<Long>map((quantity, _unit) -> quantity)).isEqualTo(5L);
     }
 
     private static void assertStringsEqualToBytes(long expectedBytes, String... byteCounts) {


### PR DESCRIPTION
This makes it obvious that the values must be used together.

==COMMIT_MSG==
Replace HumanReadableByteCount `getSize`/`getUnit` with more obvious `map(func)`
==COMMIT_MSG==

## Possible downsides?
API churn

## Alternatives?

1. We could return a new tuple type instead of taking a function. I suspect that would have a similar usability problem though.
2. We could implement an error-prone check similar to [JavaDurationGetSecondsGetNano](https://errorprone.info/bugpattern/JavaDurationGetSecondsGetNano), but I'd prefer to design APIs which needn't be accompanied by static analysis.

