### PR TITLE
Make ByteUnit in HumanReadableByteCount public

### DIFF
--- a/human-readable-types/src/main/java/com/palantir/humanreadabletypes/HumanReadableByteCount.java
+++ b/human-readable-types/src/main/java/com/palantir/humanreadabletypes/HumanReadableByteCount.java
@@ -299,7 +299,7 @@ public final class HumanReadableByteCount implements Comparable<HumanReadableByt
         return Long.toString(size) + ' ' + units;
     }
 
-    enum ByteUnit {
+    public enum ByteUnit {
         BYTE(1, "bytes"),
         KiB(1024L, "kibibytes"),
         MiB((long) Math.pow(1024L, 2L), "mebibytes"),


### PR DESCRIPTION
## Before this PR
`ByteUnit` was package access, and it needs to be public to use `SizeFunction` introduced in https://github.com/palantir/human-readable-types/pull/286

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
`ByteUnit` enum is now public, and can be used with `SizeFunction` when mapping `HumanReadableByteCount`
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

