### PR TITLE
Remove broken bintray release link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@
 # Human Readable Types
 
 [![Build Status](https://circleci.com/gh/palantir/human-readable-types.svg?style=shield)](https://circleci.com/gh/palantir/human-readable-types)
-[![JCenter Release](https://img.shields.io/github/release/palantir/human-readable-types.svg)](
-http://jcenter.bintray.com/com/palantir/human-readable-types/)
 
 This repository provides a collection of useful types that can be deserialized from human-readable strings. These types
 can be particularly useful for use in POJOs deserialized from configuration files where legibility is important.


### PR DESCRIPTION
## Before this PR
Broken bintray release link is blocking excavators, e.g. https://github.com/palantir/human-readable-types/pull/385 [build](https://app.circleci.com/pipelines/github/palantir/human-readable-types/1170/workflows/87761d38-d780-49dc-9bc3-2016c783f7bb/jobs/6419)


## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove broken bintray release link
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

