### PR TITLE
Remove unused jackson-datatype-guava dependency

### DIFF
--- a/changelog/@unreleased/pr-601.v2.yml
+++ b/changelog/@unreleased/pr-601.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Remove unused jackson-datatype-guava dependency
+  links:
+  - https://github.com/palantir/human-readable-types/pull/601

--- a/human-readable-types/build.gradle
+++ b/human-readable-types/build.gradle
@@ -17,9 +17,10 @@
 apply plugin: 'com.palantir.external-publish-jar'
 
 dependencies {
-    api 'com.fasterxml.jackson.core:jackson-databind'
+    api 'com.fasterxml.jackson.core:jackson-annotations'
     implementation 'com.palantir.safe-logging:preconditions'
 
+    testImplementation 'com.fasterxml.jackson.core:jackson-databind'
     testImplementation 'org.assertj:assertj-core'
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testImplementation 'org.junit.jupiter:junit-jupiter-api'

--- a/human-readable-types/build.gradle
+++ b/human-readable-types/build.gradle
@@ -18,7 +18,6 @@ apply plugin: 'com.palantir.external-publish-jar'
 
 dependencies {
     api 'com.fasterxml.jackson.core:jackson-databind'
-    api 'com.fasterxml.jackson.datatype:jackson-datatype-guava'
     implementation 'com.palantir.safe-logging:preconditions'
 
     testImplementation 'org.assertj:assertj-core'

--- a/versions.lock
+++ b/versions.lock
@@ -1,17 +1,10 @@
 # Run ./gradlew writeVersionsLock to regenerate this file
 com.fasterxml.jackson.core:jackson-annotations:2.15.3 (1 constraints: 8b123e21)
-com.fasterxml.jackson.core:jackson-core:2.15.3 (2 constraints: 2e29b8bc)
-com.fasterxml.jackson.core:jackson-databind:2.15.3 (2 constraints: e01b5c90)
-com.fasterxml.jackson.datatype:jackson-datatype-guava:2.15.3 (1 constraints: 3d05413b)
-com.google.code.findbugs:jsr305:3.0.2 (2 constraints: 1d0fb186)
-com.google.errorprone:error_prone_annotations:2.26.1 (2 constraints: 7f1b5d89)
-com.google.guava:failureaccess:1.0.2 (1 constraints: 150ae2b4)
-com.google.guava:guava:33.1.0-jre (2 constraints: b91e197a)
-com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava (1 constraints: bd17c918)
-com.google.j2objc:j2objc-annotations:3.0.0 (1 constraints: 150aeab4)
+com.fasterxml.jackson.core:jackson-core:2.15.3 (1 constraints: 8b123e21)
+com.fasterxml.jackson.core:jackson-databind:2.15.3 (1 constraints: 3d05413b)
+com.google.errorprone:error_prone_annotations:2.23.0 (1 constraints: 33115ed1)
 com.palantir.safe-logging:preconditions:3.7.0 (1 constraints: 0c050f36)
 com.palantir.safe-logging:safe-logging:3.7.0 (1 constraints: 061137c0)
-org.checkerframework:checker-qual:3.42.0 (2 constraints: 850fdda1)
 org.jetbrains:annotations:24.1.0 (1 constraints: 331166d1)
 
 [Test dependencies]

--- a/versions.lock
+++ b/versions.lock
@@ -1,13 +1,13 @@
 # Run ./gradlew writeVersionsLock to regenerate this file
-com.fasterxml.jackson.core:jackson-annotations:2.15.3 (1 constraints: 8b123e21)
-com.fasterxml.jackson.core:jackson-core:2.15.3 (1 constraints: 8b123e21)
-com.fasterxml.jackson.core:jackson-databind:2.15.3 (1 constraints: 3d05413b)
+com.fasterxml.jackson.core:jackson-annotations:2.15.3 (2 constraints: c717fa71)
 com.google.errorprone:error_prone_annotations:2.23.0 (1 constraints: 33115ed1)
 com.palantir.safe-logging:preconditions:3.7.0 (1 constraints: 0c050f36)
 com.palantir.safe-logging:safe-logging:3.7.0 (1 constraints: 061137c0)
 org.jetbrains:annotations:24.1.0 (1 constraints: 331166d1)
 
 [Test dependencies]
+com.fasterxml.jackson.core:jackson-core:2.15.3 (1 constraints: 8b123e21)
+com.fasterxml.jackson.core:jackson-databind:2.15.3 (1 constraints: 3d05413b)
 net.bytebuddy:byte-buddy:1.14.11 (1 constraints: 7e0bc5ea)
 org.apiguardian:apiguardian-api:1.1.2 (5 constraints: 105480ac)
 org.assertj:assertj-core:3.25.3 (1 constraints: 3f054b3b)

--- a/versions.props
+++ b/versions.props
@@ -2,7 +2,6 @@ com.fasterxml.jackson.*:jackson-* = 2.15.3
 com.fasterxml.jackson.core:jackson-databind = 2.15.3
 com.google.code.findbugs:jsr305 = 3.0.2
 com.google.errorprone:* = 2.10.0
-com.google.guava:guava = 33.1.0-jre
 com.palantir.safe-logging:* = 3.7.0
 org.assertj:* = 3.25.3
 org.checkerframework:checker-qual = 3.42.0


### PR DESCRIPTION
## Before this PR

Project declared API dependency on `com.fasterxml.jackson.datatype:jackson-datatype-guava` but does not use Jackson serialization/deserialization for Guava types.

Closes https://github.com/palantir/human-readable-types/issues/600

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Remove unused jackson-datatype-guava dependency
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

